### PR TITLE
fix missing headers

### DIFF
--- a/splite/splib/SensorFrame.h
+++ b/splite/splib/SensorFrame.h
@@ -5,6 +5,7 @@
 #pragma once
 
 #include <array>
+#include <iostream>
 
 namespace SensorGeometry
 {

--- a/splite/splib/SoundplaneModelA.cpp
+++ b/splite/splib/SoundplaneModelA.cpp
@@ -5,6 +5,7 @@
 #include "SoundplaneModelA.h"
 
 #include <math.h>
+#include <stdio.h>
 
 const char* kSoundplaneAName = ("Soundplane Model A");
 

--- a/splite/splib/SoundplaneModelA.h
+++ b/splite/splib/SoundplaneModelA.h
@@ -6,6 +6,7 @@
 #define __SOUNDPLANE_MODEL_A__
 
 #include <array>
+#include <cstdint>
 #include "SensorFrame.h"
 
 // Soundplane data format:


### PR DESCRIPTION
These changes were necessary in order to build with `clang` (on Ubuntu Linux x86).